### PR TITLE
PR. fix offline deployment. reusing bosh-release powerdns blob

### DIFF
--- a/jobs/xip/spec
+++ b/jobs/xip/spec
@@ -8,7 +8,7 @@ templates:
   pdns.conf.erb: etc/pdns.conf
 
 packages:
-- pdns-3.4.6
+- powerdns
 
 properties:
   xip.named_conf:

--- a/jobs/xip/templates/ctl.sh
+++ b/jobs/xip/templates/ctl.sh
@@ -20,7 +20,7 @@ set -e
 prefix=/var/vcap/jobs/xip/packages/powerdns
 exec_prefix=${prefix}
 BINARYPATH=${exec_prefix}/bin
-SBINARYPATH=${exec_prefix}/sbin
+SBINARYPATH=${exec_prefix}
 SOCKETPATH=/var/run
 DAEMON_ARGS=""
 PIDFILE="/var/vcap/sys/run/xip.pid"

--- a/jobs/xip/templates/ctl.sh
+++ b/jobs/xip/templates/ctl.sh
@@ -17,7 +17,7 @@
 set -e
 
 #prefix=/usr/local
-prefix=/var/vcap/jobs/xip/packages/pdns-3.4.6
+prefix=/var/vcap/jobs/xip/packages/powerdns
 exec_prefix=${prefix}
 BINARYPATH=${exec_prefix}/bin
 SBINARYPATH=${exec_prefix}/sbin

--- a/packages/powerdns/packaging
+++ b/packages/powerdns/packaging
@@ -1,0 +1,10 @@
+set -e
+
+echo "Extracting PowerDNS archive ..."
+
+mkdir -p target
+
+ar p powerdns/pdns-static_3.3.1-1_amd64.deb data.tar.gz | tar zx -C target
+
+cp -a target/usr/sbin/pdns_server ${BOSH_INSTALL_TARGET}
+cp -a target/usr/bin/pdns_control ${BOSH_INSTALL_TARGET}

--- a/packages/powerdns/spec
+++ b/packages/powerdns/spec
@@ -1,0 +1,4 @@
+---
+name: powerdns
+files:
+- powerdns/pdns-static_3.3.1-1_amd64.deb

--- a/packages/powerdns/spec.yml
+++ b/packages/powerdns/spec.yml
@@ -1,0 +1,4 @@
+---
+name: powerdns
+files:
+- powerdns/pdns-static_3.3.1-1_amd64.deb


### PR DESCRIPTION
Hello,
this is a base PR to fix internet dependency. As bosh blobs cant be PR, i submit the fix before creating final bosh release on our fork.
To align blobs
git clone
bosh sync blobs to retrieve the bosh blobstore

bosh-gen extract-pkg ../bosh/packages/powerdnsso u can copy the nginx blobs, then sync them on the cloudfoundry-community/xip-release s3 bucket
